### PR TITLE
Update composer.json for TYPO3 11 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "type": "typo3-cms-extension",
   "description": "Sends the missing PageUriGenerated PSR-14 event from the PageRouter",
   "require": {
-    "typo3/cms-core": "^10.4"
+    "typo3/cms-core": "^10.4 || ^11.5"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
No further adjustments are needed for TYPO3 11 compatibility.