### PR TITLE
[TASK] Raise PHPStan level from 2 to 4

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: composer update --prefer-dist --no-interaction --no-progress
 
-      - name: Run PHPStan level 2
+      - name: Run PHPStan level 4
         run: composer phpstan
 
   phpstan-lowest:
@@ -41,5 +41,5 @@ jobs:
       - name: Install lowest dependencies
         run: composer update --prefer-lowest --prefer-dist --no-interaction --no-progress
 
-      - name: Run PHPStan level 2
+      - name: Run PHPStan level 4
         run: composer phpstan

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,4 @@
 parameters:
-  level: 2
+  level: 4
   paths:
     - Classes


### PR DESCRIPTION
No errors at the new level — the existing code is already well-typed. Updated phpstan.neon and CI workflow step names accordingly.